### PR TITLE
added propTypes to Pagination Component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4718,7 +4718,7 @@
         "has": "1.0.3",
         "jsx-ast-utils": "2.1.0",
         "object.fromentries": "2.0.0",
-        "prop-types": "15.7.2",
+        "prop-types": "15.6.2",
         "resolve": "1.10.0"
       },
       "dependencies": {
@@ -9755,13 +9755,12 @@
       }
     },
     "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
       "requires": {
         "loose-envify": "1.4.0",
-        "object-assign": "4.1.1",
-        "react-is": "16.8.6"
+        "object-assign": "4.1.1"
       }
     },
     "property-information": {
@@ -9919,7 +9918,7 @@
       "requires": {
         "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
+        "prop-types": "15.6.2",
         "scheduler": "0.13.6"
       }
     },
@@ -10020,7 +10019,7 @@
       "requires": {
         "loose-envify": "1.4.0",
         "object-assign": "4.1.1",
-        "prop-types": "15.7.2",
+        "prop-types": "15.6.2",
         "scheduler": "0.13.6"
       }
     },

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "bootstrap": "^4.1.1",
     "font-awesome": "^4.7.0",
+    "prop-types": "^15.6.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-scripts": "3.0.1"

--- a/src/components/Pagination.js
+++ b/src/components/Pagination.js
@@ -1,5 +1,6 @@
 import React from "react";
 import _ from "lodash";
+import PropTypes from "prop-types";
 
 const Paginantion = props => {
   const { totalItems, pageSize, onPageChange, currentPage } = props;
@@ -27,6 +28,13 @@ const Paginantion = props => {
       </ul>
     </nav>
   );
+};
+
+Paginantion.propTypes = {
+  totalItems: PropTypes.number.isRequired,
+  pageSize: PropTypes.number.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  currentPage: PropTypes.number.isRequired
 };
 
 export default Paginantion;


### PR DESCRIPTION
In order to do type checking of props , added a new package "prop-types@15.6.2" in package.json.

imported the same package in Pagination Component , and added a new property to this component by saying Pagination.propType = { }.

The object assigned to this new property which has props of Pagiantion component, their types and whether they are required or not...