### PR TITLE
resets current page value when genre is changed

### DIFF
--- a/src/components/Movies.js
+++ b/src/components/Movies.js
@@ -31,7 +31,7 @@ class Movies extends Component {
   }
 
   handleGenreSelection = genre => {
-    this.setState({ currentGenre: genre });
+    this.setState({ currentGenre: genre, currentPage: 1 });
   };
 
   handleLike(movie) {


### PR DESCRIPTION
While on All Genre option everything worked fine.........on every page(currently 1,2,3 ) I was able to see movies data. If I have made a selection of All Genre and page 2/3....and then switch to any other genre whose movies count is less than pageSize......then no movies data was displayed....
Because while switching to another genre, current page value remained same and which showed us same page of currentGenre 
Steps To Reproduced : 
1. Launch the App and select All Genre 
2. click 2 on pagination tab...
3. Select Action from filter see the observation.......
here technically  we are at page number 2 of Action genre which actually does not have any data........

So while changing Genre I resetted the current page value to 1 which resolved the defect...........
Now whenever I change Genre ....By default I am shown data from 1st page.............